### PR TITLE
Fix incorrect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Homebrew Tap for the [Imgbrd-Grabber](https://github.com/Bionus/imgbrd-grabber) 
 ## Usage
 ```
 brew tap Bionus/imgbrd-grabber
-brew install cask imgbrd-grabber-nightly
+brew cask install imgbrd-grabber-nightly
 ```


### PR DESCRIPTION
Thanks for making the brew install command. Very much appreciated as I install all my apps this way.

I just installed via `brew` and noticed the readme had the command mixed up ^_^ Here's an example and brew suggests doing it correctly.

<img width="479" alt="Screen Shot 2020-04-05 at 9 41 36 PM" src="https://user-images.githubusercontent.com/5648875/78518486-3cf16f00-7786-11ea-9ca1-4b0c83779aac.png">

---

Also, as a note to anyone running into this issue with macOS, the latest version (10.15) has this stupid error with 3rd party apps when opening them for the first time. The error in question is:

`macOS Catalina: “App is damaged and can't be opened. You should move it to the trash.”`

Here's a [StackExchange Answer](https://apple.stackexchange.com/questions/372084/macos-catalina-app-is-damaged-and-cant-be-opened-you-should-move-it-to-the-t/372208?noredirect=1#comment515001_372208) where I provided the solution for someone else and here it is for grabber as well:

`sudo xattr -rd com.apple.quarantine /Applications/grabber.app`

After that, I had no issues.

---

Wow, the performance has greatly improved since I last updated the app. Everything loads so fast now!