### PR TITLE
Fix brew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Homebrew Tap for the [Imgbrd-Grabber](https://github.com/Bionus/imgbrd-grabber) 
 ## Usage
 ```
 brew tap Bionus/imgbrd-grabber
-brew install cask imgbrd-grabber-nightly
+brew install imgbrd-grabber-nightly
 ```


### PR DESCRIPTION
I no longer had PR #1 on hand as I did that a long time ago, so I closed it and opened a new one. You can see on my notes in that PR that `--cask` turned out to be optional. Again, here it is working successfully like this:

```
❯ brew install imgbrd-grabber-nightly
==> Downloading https://github.com/Bionus/imgbrd-grabber/releases/download/nightly/Grabber_nightly.dm
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/32276615/fe92470
######################################################################## 100.0%
Warning: No checksum defined for cask 'imgbrd-grabber-nightly', skipping verification.
==> Installing Cask imgbrd-grabber-nightly
==> Moving App 'grabber.app' to '/Applications/grabber.app'.
🍺  imgbrd-grabber-nightly was successfully installed!

~ took 15s 
```